### PR TITLE
docs: rename references from Spectral API to Spectrum API throughout …

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""Main application entry point for the Spectral API.
+"""Main application entry point for the Spectrum API.
 
 This module sets up the FastAPI application with spectrum analysis
 endpoints and authentication middleware. It provides the main API

--- a/src/spectrum_api/config/auth.py
+++ b/src/spectrum_api/config/auth.py
@@ -1,4 +1,4 @@
-"""Authentication module for the Spectral API.
+"""Authentication module for the Spectrum API.
 
 This module provides API key-based authentication using FastAPI's
 security features. It validates API keys from request headers against

--- a/src/spectrum_api/constants.py
+++ b/src/spectrum_api/constants.py
@@ -1,4 +1,4 @@
-"""Constants for the SpectralAPI.
+"""Constants for the SpectrumAPI.
 
 This module defines application-wide constants including spectrum_api metadata,
 environment variable names, and field identifiers used throughout the

--- a/src/spectrum_api/models/input_models.py
+++ b/src/spectrum_api/models/input_models.py
@@ -1,4 +1,4 @@
-"""Input models for the SpectralAPI.
+"""Input models for the SpectrumAPI.
 
 This module defines the Pydantic models used for spectrum analysis requests
 and responses, including validation logic for input data.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test package for the Spectral API project."""
+"""Test package for the Spectrum API project."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Fixture definitions for the SpectralAPI tests."""
+"""Fixture definitions for the SpectrumAPI tests."""
 
 from unittest.mock import MagicMock
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-"""Test utilities for the SpectralAPI tests.
+"""Test utilities for the SpectrumAPI tests.
 
 This module contains reusable test components including signal
 generators and test data structures for spectrum analysis testing. It


### PR DESCRIPTION
Close #9 